### PR TITLE
Replace lsp state with localStorage state when storage event fires

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:deps": "dependency-check . --no-dev --no-peer",
     "test:standard": "standard",
     "test:tape": "browserify test.cjs | tape-run",
+    "test:node": "tape test.cjs",
     "version": "auto-changelog -p --template keepachangelog auto-changelog --breaking-pattern 'BREAKING CHANGE:' && git add CHANGELOG.md"
   },
   "standard": {

--- a/test.cjs
+++ b/test.cjs
@@ -3,8 +3,10 @@ const ptape = require('tape-promise').default
 const test = ptape(tape)
 const localStorageProxy = require('.').default
 
+const isBrowser = typeof window !== 'undefined'
+
 test('test basic behavior', async t => {
-  window.localStorage.clear()
+  if (isBrowser) window.localStorage.clear()
   const state = localStorageProxy('test', {
     defaults: {
       foo: 'bar',
@@ -16,7 +18,7 @@ test('test basic behavior', async t => {
   })
   t.equal(state.foo, 'bar')
   state.biz.push('bing')
-  t.equal(window.localStorage.getItem('test'), '{"foo":"bar","biz":["baz","bing"],"bing":{"pow":true},"lspReset":false}')
+  if (isBrowser) t.equal(window.localStorage.getItem('test'), '{"foo":"bar","biz":["baz","bing"],"bing":{"pow":true},"lspReset":false}')
 
   const state2 = localStorageProxy('test', {
     lspReset: false,
@@ -59,7 +61,7 @@ test('test basic behavior', async t => {
     t.equal(state4.beep, 'boop', 'cought the update')
     state4.removeEventListener('update', eventHandler)
     state4.addEventListener('update', secondHandler)
-    window.localStorage.setItem('foo', 'bar')
+    if (isBrowser) window.localStorage.setItem('foo', 'bar')
   }
 
   state4.addEventListener('update', eventHandler)


### PR DESCRIPTION
The lsp state needs to be refreshed from localStorage when the storage event fires. This implements that. This was a bug in 4.0.0.